### PR TITLE
Add support for media types

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,15 +202,16 @@
     "        if path[:7] not in ('http://','https:/'): path = GH_HOST+path\n",
     "        if route:\n",
     "            for k,v in route.items(): route[k] = quote(str(route[k]))\n",
+    "        return_json = ('json' in headers['Accept'])\n",
     "        res,self.recv_hdrs = urlsend(path, verb, headers=headers or None, debug=self.debug, return_headers=True,\n",
-    "                                     route=route or None, query=query or None, data=data or None)\n",
+    "                                     route=route or None, query=query or None, data=data or None, return_json=return_json)\n",
     "        if 'X-RateLimit-Remaining' in self.recv_hdrs:\n",
     "            newlim = self.recv_hdrs['X-RateLimit-Remaining']\n",
     "            if self.limit_cb is not None and newlim != self.limit_rem:\n",
     "                self.limit_cb(int(newlim),int(self.recv_hdrs['X-RateLimit-Limit']))\n",
     "            self.limit_rem = newlim\n",
     "            \n",
-    "        return dict2obj(res)\n",
+    "        return dict2obj(res) if return_json else res\n",
     "\n",
     "    def __dir__(self): return super().__dir__() + list(self.groups)\n",
     "    def _repr_markdown_(self): return \"\\n\".join(f\"- [{o}]({_docroot + o.replace('_', '-')})\" for o in sorted(self.groups))\n",
@@ -227,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -270,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -296,21 +297,21 @@
        "- node_id: MDM6UmVmMzE1NzEyNTg4OnJlZnMvaGVhZHMvbWFzdGVy\n",
        "- url: https://api.github.com/repos/fastai/ghapi-test/git/refs/heads/master\n",
        "- object: \n",
-       "  - sha: 164355601ff88f0482d90f2e1bc7b7546a9bacef\n",
+       "  - sha: d0605f3abc070f4790501db038c24223379007a5\n",
        "  - type: commit\n",
-       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/164355601ff88f0482d90f2e1bc7b7546a9bacef"
+       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/d0605f3abc070f4790501db038c24223379007a5"
       ],
       "text/plain": [
        "- ref: refs/heads/master\n",
        "- node_id: MDM6UmVmMzE1NzEyNTg4OnJlZnMvaGVhZHMvbWFzdGVy\n",
        "- url: https://api.github.com/repos/fastai/ghapi-test/git/refs/heads/master\n",
        "- object: \n",
-       "  - sha: 164355601ff88f0482d90f2e1bc7b7546a9bacef\n",
+       "  - sha: d0605f3abc070f4790501db038c24223379007a5\n",
        "  - type: commit\n",
-       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/164355601ff88f0482d90f2e1bc7b7546a9bacef"
+       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/d0605f3abc070f4790501db038c24223379007a5"
       ]
      },
-     "execution_count": 27,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -322,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -355,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -365,27 +366,63 @@
        "- node_id: MDM6UmVmMzE1NzEyNTg4OnJlZnMvaGVhZHMvbWFzdGVy\n",
        "- url: https://api.github.com/repos/fastai/ghapi-test/git/refs/heads/master\n",
        "- object: \n",
-       "  - sha: 164355601ff88f0482d90f2e1bc7b7546a9bacef\n",
+       "  - sha: d0605f3abc070f4790501db038c24223379007a5\n",
        "  - type: commit\n",
-       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/164355601ff88f0482d90f2e1bc7b7546a9bacef"
+       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/d0605f3abc070f4790501db038c24223379007a5"
       ],
       "text/plain": [
        "- ref: refs/heads/master\n",
        "- node_id: MDM6UmVmMzE1NzEyNTg4OnJlZnMvaGVhZHMvbWFzdGVy\n",
        "- url: https://api.github.com/repos/fastai/ghapi-test/git/refs/heads/master\n",
        "- object: \n",
-       "  - sha: 164355601ff88f0482d90f2e1bc7b7546a9bacef\n",
+       "  - sha: d0605f3abc070f4790501db038c24223379007a5\n",
        "  - type: commit\n",
-       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/164355601ff88f0482d90f2e1bc7b7546a9bacef"
+       "  - url: https://api.github.com/repos/fastai/ghapi-test/git/commits/d0605f3abc070f4790501db038c24223379007a5"
       ]
      },
-     "execution_count": 29,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "api['/repos/{owner}/{repo}/git/ref/{ref}'](owner='fastai', repo='ghapi-test', ref='heads/master')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Media types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For some endpoints GitHub lets you specify a [media type](https://docs.github.com/en/rest/overview/media-types) the for response data, using the `Accept` header. If you choose a media type that is not JSON formatted (for instance `application/vnd.github.v3.sha`) then the call to the `GhApi` object will return a string instead of an object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'d0605f3abc070f4790501db038c24223379007a5'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "api('/repos/{owner}/{repo}/commits/{ref}', 'GET', route=dict(\n",
+    "    owner='fastai', repo='ghapi-test', ref='refs/heads/master'),\n",
+    "    headers={'Accept': 'application/vnd.github.VERSION.sha'})"
    ]
   },
   {
@@ -404,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -420,7 +457,7 @@
        "'refs/heads/master'"
       ]
      },
-     "execution_count": 30,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -441,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -450,7 +487,7 @@
        "'4997'"
       ]
      },
-     "execution_count": 31,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -479,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -544,7 +581,7 @@
        "<__main__.GhApi at 0x7fb6fc2b81c0>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -555,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -569,7 +606,7 @@
        "<__main__._GhVerbGroup at 0x7fb70c02ff70>"
       ]
      },
-     "execution_count": 34,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -596,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -621,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -633,7 +670,7 @@
        "[repos.create_webhook](https://docs.github.com/rest/reference/repos#create-a-repository-webhook)(name, config, events, active): *Create a repository webhook*"
       ]
      },
-     "execution_count": 36,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -651,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +705,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -677,7 +714,7 @@
        "('/repos/fastai/ghapi-test/git/ref/{ref}', 'get')"
       ]
      },
-     "execution_count": 38,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -695,7 +732,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -719,7 +756,7 @@
        "<__main__._GhVerbGroup at 0x7fb70c07fd00>"
       ]
      },
-     "execution_count": 39,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -737,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +838,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -809,7 +846,7 @@
       "text/markdown": [],
       "text/plain": []
      },
-     "execution_count": 44,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -827,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -855,7 +892,7 @@
        "3"
       ]
      },
-     "execution_count": 46,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -868,7 +905,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,7 +917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -912,7 +949,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -931,7 +968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -974,7 +1011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -988,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -998,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1014,7 +1051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1039,7 +1076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1049,7 +1086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1077,7 +1114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1110,7 +1147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1155,7 +1192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1175,7 +1212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1212,7 +1249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1242,7 +1279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1265,7 +1302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1308,7 +1345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1322,7 +1359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1344,7 +1381,7 @@
        "- url: https://api.github.com/repos/fastai/ghapi-test/git/blobs/9b33a4362dda251455f7e4d99554467d1e6ba024"
       ]
      },
-     "execution_count": 74,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1356,7 +1393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1369,7 +1406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1379,7 +1416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1396,7 +1433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1405,7 +1442,7 @@
        "72"
       ]
      },
-     "execution_count": 78,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1421,7 +1458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,7 +1469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1466,7 +1503,7 @@
       "text/markdown": [],
       "text/plain": []
      },
-     "execution_count": 81,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1488,7 +1525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1528,31 +1565,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": false,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For some endpoints GitHub lets you request different response format using the `Accept` header [[1]]. However, by default if the response is not in JSON format `GhApi.__call__` will raise an error.

This PR makes it possible by adding a bit of logic to look at the `Accept` header in the request and tell `fastcore.core.urlsend` not to return JSON if it doesn't look like the user is requesting a JSON media type.

[1]: https://docs.github.com/en/rest/overview/media-types